### PR TITLE
FlowScript set command sets deep attributes

### DIFF
--- a/docs/flowscript.md
+++ b/docs/flowscript.md
@@ -1,6 +1,10 @@
 # FlowScript
 
-DeepDialog flows enable developers to script interactions using JSON or YAML data format.  Code-as-data makes it easy to generate bot interactions dynamically.  FlowScript wraps service objects that interact with the DeepDialog API, and provides a high level interface that makes it easy to start dialogs, capture results, program action buttons, and use branching logic and iteration.  The core service objects that interact with the DeepDialog API are covered [here](./index.md).
+FlowScript is a high-level language that lets a chatbot developer write conversational flows using JSON or YAML. Flows are designed to make it easy to read and write chatbot logic.  A flow is a sequence of commands for the bot to execute, and can include buttons, branching logic, and the ability to start modules called dialogs and capture results.  
+
+In practical terms, a flow is a JS Array, and commands are JS Objects, strings or functions.  This means a developer can generate flows programmatically.  In fact, parts of the flow can be generated dynamically when a function (called a handler) is substituted for some part of the data structure.  For example, it's easy to generate buttons with a function which returns an array of Objects representing buttons.  You can drive a conversation
+
+ FlowScript provides a high level interface to the DeepDialog API, but also provides access to the lower level service objects (such as the DeepDialog Session). See the documentation [here](./index.md).
 
 
 ### Example
@@ -445,6 +449,11 @@ Set session variables
   // returned key-value pairs which will be set.
   async set({userId}) {return await db.getUserAddress(userId); }
 }
+
+// shorthand for setting a deep attribute
+// child objects are created automatically
+// existing keys in parent objects are retained:
+{ set: {"user.home.address": "420 Paper St."}}
 ```
 
 ### Start command

--- a/src/flowdialog.js
+++ b/src/flowdialog.js
@@ -1,6 +1,7 @@
 import {isObject, isString, isArray, isFunction} from 'util';
 import micromustache from 'micromustache';
 
+import {setPath} from './objpath';
 import {anyPattern} from './constants';
 import Dialog from './dialog';
 var util = require('./util'); // so we can stub sleep in tests
@@ -211,7 +212,12 @@ export default class FlowDialog extends Dialog {
 
   _compileSetCommand(cmd, path) {
     return async (vars, session) => {
-      await session.save(await this._expandCommandParam(cmd.set, vars, session, path));
+      var expandedVars = await this._expandCommandParam(cmd.set, vars, session, path);
+      var processedVars = {};
+      for (let v in expandedVars) {
+        setPath(processedVars, v, expandedVars[v]);
+      }
+      await session.save(processedVars);
     };
   }
 

--- a/src/objpath.js
+++ b/src/objpath.js
@@ -1,0 +1,16 @@
+import {isString} from 'util';
+
+export function pathToArray(path) { return isString(path) ? path.split('.') : path; }
+export function setPath(obj, path, value) {
+  path = pathToArray(path);
+  var [head, ...tail] = path;
+  if (tail.length==0) {
+    obj[head] = value;
+  } else {
+    var nextObj = obj[head];
+    if (!nextObj) {
+      nextObj = obj[head] = {};
+    }
+    setPath(nextObj, tail, value);
+  }
+}

--- a/tests/flowdialog.test.js
+++ b/tests/flowdialog.test.js
@@ -851,6 +851,19 @@ describe('FlowScript', function () {
             sinon.match({b:1})
           ).calledOnce).to.be.true;
         });
+
+        it('should call session set, automatically generating objects in a path', async function () {
+          var session = { save: sinon.stub() };
+          var dialog = new FlowDialog({name:"TestFlowDialog", flows: {}});
+
+          var handler = dialog._compileFlow([
+            {set:()=>({"a.b.c":1, "a.b.d":2, "a.e":3 })}
+          ], ['onStart']);
+          await handler({}, session, []);
+          expect(session.save.withArgs(
+            sinon.match({a:{b:{c:1, d:2}, e:3}})
+          ).calledOnce).to.be.true;
+        });
       });
 
       context('finish command', function () {


### PR DESCRIPTION
{set: {"a.b.c": 1}} // creates sub objects and assigns values to child keys without deleting sibling keys