### PR TITLE
Enable continuation of flows after flow-breaking command

### DIFF
--- a/tests/session.test.js
+++ b/tests/session.test.js
@@ -1,6 +1,6 @@
 import {expect} from 'chai';
 
-import {Session, App, Dialog} from '..';
+import {Session, App, Dialog} from '../src';
 
 describe('Session', function () {
   context('Constructor', function () {


### PR DESCRIPTION
For example, it is now possible to have commands after a
start command or a message with actions with then flows.
The commands after the flow breaking command only execute
after the breaking command's then block executes."