### PR TITLE
Fix Dokku deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,14 +34,9 @@
     "lib": ""
   },
   "devDependencies": {
-    "babel-cli": "6.x.x",
-    "babel-core": "6.x.x",
     "babel-eslint": "6.0.0-beta.6",
     "babel-plugin-transform-runtime": "6.x.x",
-    "babel-polyfill": "6.x.x",
-    "babel-preset-env": "1.2.2",
     "babel-preset-es2015": "6.x.x",
-    "babel-preset-stage-3": "6.24.1",
     "chai": "3.5.0",
     "dotenv": "2.0.0",
     "eslint": "3.12.2",
@@ -52,6 +47,9 @@
     "sinon": "2.3.5"
   },
   "dependencies": {
+    "babel-cli": "6.24.1",
+    "babel-preset-env": "1.6.0",
+    "babel-preset-stage-3": "6.24.1",
     "babel-runtime": "6.x.x",
     "body-parser": "1.16.0",
     "compression": "1.6.2",

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -1,5 +1,5 @@
 echo "> Start transpiling ES2015"
 echo ""
-../../node_modules/.bin/babel src --out-dir lib
+./node_modules/.bin/babel src --out-dir lib
 echo ""
 echo "> Complete transpiling ES2015"


### PR DESCRIPTION
On Dokku, the package doesn't have access to the parent's node_modules
directory, so we use a local copy of the babel transpiler.