### PR TITLE
Fix bug in finish command

### DIFF
--- a/src/flowdialog.js
+++ b/src/flowdialog.js
@@ -1096,6 +1096,7 @@ export function isFlowBreaker(cmd) {
       cmd.type=='iteration' ||
       cmd.type=='start' ||
       cmd.type=='break' ||
+      cmd.type=='finish' ||
       (
         isMessageType(cmd.type) && (
           actionsHasFlowBreakers(cmd.actions) ||
@@ -1154,7 +1155,7 @@ export function inferCommandType(command) {
     return 'image'; // this must come before command.text inference
   } else if (command.text) {
     return 'text';
-  } else if (command.finish) {
+  } else if (command.hasOwnProperty('finish')) { // value could be null or false
     return 'finish';
   } else if (command.start) {
     return 'start';

--- a/tests/flowdialog.test.js
+++ b/tests/flowdialog.test.js
@@ -50,6 +50,10 @@ describe('FlowScript', function () {
       it('should be "finish" if "finish" key is present', function () {
         expect(inferCommandType({finish:true})).to.equal('finish');
       });
+      it('should be "finish" if "finish" key is present even if value is falsey', function () {
+        expect(inferCommandType({finish:false})).to.equal('finish');
+        expect(inferCommandType({finish:null})).to.equal('finish');
+      });
       it('should be "wait" if "seconds" key is present', function () {
         expect(inferCommandType({wait:5})).to.equal("wait");
       });


### PR DESCRIPTION
* {finish:null} or {finish:false} is now detected correctly
* finish command is now treated as a flow breaker