### PR TITLE
Add operators and references to dollar operator

### DIFF
--- a/tests/flowdialog.test.js
+++ b/tests/flowdialog.test.js
@@ -2036,6 +2036,110 @@ describe('FlowScript', function () {
       it("should return a handler which returns undefined if a function doesn't exist", function () {
         expect($.a.$toLowerCase()({a:1})).to.be.undefined;
       });
+
+      context('when prebuilt operators', function () {
+        it('should correctly perform gt test', function () {
+          expect($.a.b.$gt(3)({a:{b:1}})).to.be.false;
+          expect($.a.b.$gt(3)({a:{b:3}})).to.be.false;
+          expect($.a.b.$gt(3)({a:{b:4}})).to.be.ok;
+        });
+
+        it('should correctly perform lt test', function () {
+          expect($.a.b.$lt(3)({a:{b:4}})).to.be.false;
+          expect($.a.b.$lt(3)({a:{b:3}})).to.be.false;
+          expect($.a.b.$lt(3)({a:{b:2}})).to.be.ok;
+        });
+
+        it('should correctly perform gte test', function () {
+          expect($.a.b.$gte(3)({a:{b:1}})).to.be.false;
+          expect($.a.b.$gte(3)({a:{b:3}})).to.be.ok;
+          expect($.a.b.$gt(3)({a:{b:4}})).to.be.ok;
+        });
+
+        it('should correctly perform lte test', function () {
+          expect($.a.b.$lte(3)({a:{b:4}})).to.be.false;
+          expect($.a.b.$lte(3)({a:{b:3}})).to.be.ok;
+          expect($.a.b.$lte(3)({a:{b:2}})).to.be.ok;
+        });
+
+        it('should correctly perform equals test', function () {
+          expect($.a.b.$equals(3)({a:{b:4}})).to.be.false;
+          expect($.a.b.$equals(3)({a:{b:3}})).to.be.ok;
+        });
+
+        it('should correctly perform equals test with a reference', function () {
+          expect($.a.b.$equals($.c)({a:{b:4}, c:3})).to.be.false;
+          expect($.a.b.$equals($.c)({a:{b:3}, c:3})).to.be.ok;
+        });
+
+        it('should correctly perform isTruthy test', function () {
+          expect($.a.b.$isTruthy()({a:{b:false}})).to.be.false;
+          expect($.a.b.$isTruthy()({a:{b:null}})).to.be.false;
+          expect($.a.b.$isTruthy()({a:null})).to.not.be.ok;
+          expect($.a.b.$isTruthy()({a:undefined})).to.not.be.ok;
+          expect($.a.b.$isTruthy()({a:{b:1}})).to.be.ok;
+          expect($.a.b.$isTruthy()({a:{b:true}})).to.be.ok;
+        });
+
+        it('should correctly perform isFalsey test', function () {
+          expect($.a.b.$isFalsey()({a:{b:false}})).to.be.ok;
+          expect($.a.b.$isFalsey()({a:{b:null}})).to.be.ok;
+          expect($.a.b.$isFalsey()({a:null})).to.be.ok;
+          expect($.a.b.$isFalsey()({a:undefined})).to.be.ok;
+          expect($.a.b.$isFalsey()({a:{b:1}})).to.be.false;
+          expect($.a.b.$isFalsey()({a:{b:true}})).to.be.false;
+        });
+
+        it('should correctly perform isArray test', function () {
+          expect($.a.b.$isArray()({a:{b:[1,2,3]}})).to.be.ok;
+          expect($.a.b.$isArray()({a:{b:1}})).to.not.be.ok;
+        });
+
+        it('should correctly perform isPlainObject test', function () {
+          expect($.a.b.$isPlainObject()({a:{b:[1,2,3]}})).to.not.be.ok;
+          expect($.a.b.$isPlainObject()({a:{b:{c:1}}})).to.be.ok;
+        });
+
+        it('should correctly perform isString test', function () {
+          expect($.a.b.$isString()({a:{b:[1,2,3]}})).to.not.be.ok;
+          expect($.a.b.$isString()({a:{b:"abc"}})).to.be.ok;
+        });
+
+        it('should correctly perform isNull test', function () {
+          expect($.a.b.$isNull()({a:{b:false}})).to.not.be.ok;
+          expect($.a.b.$isNull()({a:{b:null}})).to.be.ok;
+        });
+
+        it('should correctly perform isUndefined test', function () {
+          expect($.a.b.$isUndefined()({a:{b:null}})).to.not.be.ok;
+          expect($.a.b.$isUndefined()({a:{b:undefined}})).to.be.ok;
+        });
+
+        it('should correctly perform isNumber test', function () {
+          expect($.a.b.$isNumber()({a:{b:1}})).to.be.ok;
+          expect($.a.b.$isNumber()({a:{b:"hello"}})).to.not.be.ok;
+        });
+
+        it('should correctly perform add', function () {
+          expect($.a.b.$add(5)({a:{b:2}})).to.equal(7);
+        });
+
+        it('should correctly perform sub', function () {
+          expect($.a.b.$sub(2)({a:{b:5}})).to.equal(3);
+        });
+
+        it('should correctly perform mul', function () {
+          expect($.a.b.$mul(3)({a:{b:4}})).to.equal(12);
+        });
+
+        it('should correctly perform div', function () {
+          expect($.a.b.$div(3)({a:{b:12}})).to.equal(4);
+        });
+
+        it('should correctly perform pow', function () {
+          expect($.a.b.$pow(3)({a:{b:2}})).to.equal(8);
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
It is now possible to do:

{ if: $.a.($.b), then: [...]} // runs the then block if session variable a > b

Operators implemented:
  tests: gt, lt, gte, lte, equals, isNull, isUndefined, isArray, isPlainObject, isString, isNumber, isTruthy, isFalsey
  ops: add, sub, div, mul, pow