### PR TITLE
Fix dollar operator - avoid own-property interception

### DIFF
--- a/docs/flowscript.md
+++ b/docs/flowscript.md
@@ -209,6 +209,17 @@ var addOne = x=>x+1;
 $.a.b.$(addOne)({a:{b:3}}) // => 4
 ```
 
+##### Call key is forbidden!!
+
+```javascript
+$.call         // behavior is undefined
+$.a.b.c.call   // behavior is undefined!
+
+// instead, use a function
+({call})=>call  // instead of $.call
+({a})=>a.b.c.call  // instead of $.a.b.c.call
+```
+
 See also the [Advanced Topics](#advanced-topics) section.
 
 ### Named Handlers

--- a/src/dollar-operator.js
+++ b/src/dollar-operator.js
@@ -81,10 +81,8 @@ function handlerPropertyProxy(handler) {
   return new Proxy(handler, {
     get (target, property) {
       if (
-        target.hasOwnProperty(property) ||
         !isString(property) ||
-        property=='call' ||
-        property=='inspect'
+        property=='call'
       ) {
         return target[property];
       } else if (property.startsWith('$')) {

--- a/tests/flowdialog.test.js
+++ b/tests/flowdialog.test.js
@@ -1908,6 +1908,41 @@ describe('FlowScript', function () {
 
         });
 
+        it('should correctly run an iteration with a nested conditional', async function () {
+          var dialog = new FlowDialog({name:"TestFlowDialog", flows: {}});
+          var events = [];
+          var session = {
+            async send(params) { events.push({send:params}); },
+            async save(params) {
+              this.locals=params;
+            },
+            locals:{},
+            globals:{}
+          };
+          var isEven = (x)=>x%2==0;
+          var handler = dialog._compileFlow([
+            {
+              until: $.i.$gt(2),
+              do: [
+                {
+                  if: $.i.$(isEven),
+                  then: "{{i}} is even",
+                  else: "{{i}} is odd"
+                },
+                {set: {i:$.i.$add(1)}}
+              ]
+            }
+          ],
+          ['onStart']);
+
+          session.locals = {i:0};
+          await handler({}, session);
+          expect(events).to.deep.equal([
+            {send:{type:"text", text:"0 is even"}},
+            {send:{type:"text", text:"1 is odd"}},
+            {send:{type:"text", text:"2 is even"}}
+          ]);
+        });
       });
 
       context('message command', function () {


### PR DESCRIPTION
The dollar operator now only intercepts the .call property, avoiding
failure of expressions such as

because name is a defined property of Function.