### PR TITLE
Fix set command bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepdialog",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Node client for interacting with DeepDialog service",
   "engines": {
     "npm": "5.1.0",
@@ -20,6 +20,7 @@
   },
   "scripts": {
     "prepublishOnly": ". ./scripts/prepublishOnly.sh",
+    "coverage": "istanbul cover _mocha -- $npm_package_options_mocha",
     "build": "./node_modules/.bin/babel src --out-dir lib",
     "postinstall": ". ./scripts/postinstall.sh",
     "lint": "eslint ./src",

--- a/src/flowdialog.js
+++ b/src/flowdialog.js
@@ -317,7 +317,7 @@ export default class FlowDialog extends Dialog {
 
   async _expandSetParam(params, vars, session, path) {
     var expandedVars = await this._expandCommandParam(params, vars, session, path);
-    var processedVars = {};
+    var processedVars = {...vars};
     const destructureRegex = /\{([\s\w,]*)}/;
 
     for (let v in expandedVars) {

--- a/tests/flowdialog.test.js
+++ b/tests/flowdialog.test.js
@@ -721,7 +721,7 @@ describe('FlowScript', function () {
 
       it('should expand functions in a provided object', async function() {
         expect(await dialog._expandSetParam({a:()=>1, b:2, c:$.z}, {z:3})).to.deep.equal({
-          a:1, b:2, c:3
+          a:1, b:2, c:3, z:3
         });
       });
 
@@ -1223,9 +1223,9 @@ describe('FlowScript', function () {
           var handler = dialog._compileFlow([
             {set:()=>({"a.b.c":1, "a.b.d":2, "a.e":3 })}
           ], ['onStart']);
-          await handler({}, session, []);
+          await handler({a:{x:1, b:{x:2}} }, session, []);
           expect(session.save.withArgs(
-            sinon.match({a:{b:{c:1, d:2}, e:3}})
+            sinon.match({a:{x:1, b:{c:1, d:2, x:2}, e:3}})
           ).calledOnce).to.be.true;
         });
 

--- a/tests/objpath.test.js
+++ b/tests/objpath.test.js
@@ -1,0 +1,17 @@
+import {setPath} from '../src/objpath';
+import {expect} from 'chai';
+
+describe('objpath', function () {
+  context('setPath', function () {
+    it('should set a value in a deep path', function () {
+      var obj= {};
+      setPath(obj, 'a.b.c', 1);
+      expect(obj).to.deep.equal({a:{b:{c:1}}});
+    });
+    it('should set a value in a deep path without changing other keys', function () {
+      var obj= {a:{b:{c:1}}};
+      setPath(obj, 'a.b.d', 2);
+      expect(obj).to.deep.equal({a:{b:{c:1, d:2}}});
+    });
+  });
+});


### PR DESCRIPTION
{ set: {"a.b.c":1} } no longer wipes out sibling keys of b and c