### PR TITLE
Add explicit flow commands to fix problem with naming/retrieval of next flows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepdialog",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Node client for interacting with DeepDialog service",
   "engines": {
     "npm": "5.1.0",


### PR DESCRIPTION
This adds a `{ flow: [...] }` command which allows wrapping a flow and providing
it with an explicit id. This avoids ambiguities in naming child elements in subflows,
and provides clearer more explicit method for representing a flow point.